### PR TITLE
Add auto-assign-on-comment.yml

### DIFF
--- a/.github/workflows/auto-assign-on-comment.yml
+++ b/.github/workflows/auto-assign-on-comment.yml
@@ -1,0 +1,52 @@
+name: Auto Assign on 'take' Comment
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  issues: write
+jobs:
+  assign:
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
+    if: (!github.event.issue.pull_request) && contains(github.event.comment.body, 'take')
+    concurrency:
+      group: ${{ github.actor }}-auto-assign-issue
+      cancel-in-progress: true
+    steps:
+      - name: Auto assign if comment includes 'take'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.toLowerCase();
+            const author = context.payload.comment.user.login;
+            const issue = context.payload.issue;
+
+            // Check if comment includes 'take'
+            if (!body.includes('take')) {
+              console.log("Comment does not include 'take'; skipping.");
+              return;
+            }
+
+            // Check if already assigned
+            const alreadyAssigned = issue.assignees.find(a => a.login === author);
+            if (alreadyAssigned) {
+              console.log(`${author} is already assigned; skipping.`);
+              return;
+            }
+
+            // Check if there is any other assignee
+            if (issue.assignees.length > 0) {
+              console.log("Issue already has an assignee; skipping assignment.");
+              return;
+            }
+
+            // Assign to commenter
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [author],
+            });
+
+            console.log(`Assigned ${author} to issue #${issue.number}`);


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds a GitHub Actions workflow that automatically assigns an issue to a commenter when they post a comment containing the keyword `take`.

 - Skip if the comment does not include the keyword "take".
 - Skip if the commenter is already assigned to the issue.
 - Skip if the issue already has another assignee.
 - Runs on a self-hosted runner from the `databrickslabs-protected-runner-group`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated the relevant server README.md

### Release Notes

N/A

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

