### PR TITLE
chore: fix github auto assign on comment workflow

### DIFF
--- a/.github/workflows/auto-assign-on-comment.yml
+++ b/.github/workflows/auto-assign-on-comment.yml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.comment.body.toLowerCase();
+            const body = context.payload.comment.body.trim();
             const author = context.payload.comment.user.login;
             const issue = context.payload.issue;
 
-            // Check if comment includes 'take'
-            if (!body.includes('take')) {
-              console.log("Comment does not include 'take'; skipping.");
+            // Check if comment is 'take'
+            if (body !== 'take') {
+              console.log("Comment is not exactly 'take'; skipping.");
               return;
             }
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #26 

### What changes are proposed in this pull request?

This PR updates the Auto Assign on 'take' Comment workflow to assign the issue only when the comment is exactly the word `take`, ignoring surrounding whitespace.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated the relevant server README.md

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

