### PR TITLE
Fix uvicorn command in custom-server README

### DIFF
--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -19,7 +19,7 @@ uv sync
 - start the server locally. Changes will trigger a reload:
 
 ```bash
-uvicorn custom-server.app:mcp --reload
+uvicorn custom_server.app:app --reload
 ```
 
 ## Deploying a custom MCP server on Databricks Apps


### PR DESCRIPTION
The command had two issues:
1. Used 'custom-server' instead of 'custom_server' (Python modules use underscores)
2. Referenced ':mcp' instead of ':app' (the FastAPI instance is named 'app')

🤖 Generated with [Claude Code](https://claude.ai/code)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

README update.

### How is this PR tested?

Only README.md is changed

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

No. The PR is itself a documentation update. 

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes.
Fixed bug in custom-server README.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

