### PR TITLE
Small fix for column filtering 

### DIFF
--- a/src/databricks/labs/mcp/servers/unity_catalog/tools/vector_search.py
+++ b/src/databricks/labs/mcp/servers/unity_catalog/tools/vector_search.py
@@ -6,13 +6,15 @@ from databricks.labs.mcp.servers.unity_catalog.tools.base_tool import BaseTool
 from databricks.labs.mcp.servers.unity_catalog.cli import CliSettings
 from mcp.types import TextContent, Tool as ToolSpec
 
-# Constant to filter vector column and expose by default the otherS columns presented in the index
-CONTENT_VECTOR_COLUMN_STARTS_WITH= "__db_"
-CONTENT_VECTOR_COLUMN_ENDS_WITH= "_vector"
+# Constants used to identify vector columns by name.
+# Columns matching both patterns will be excluded; all others will be returned.
+CONTENT_VECTOR_COLUMN_STARTS_WITH = "__db_"
+CONTENT_VECTOR_COLUMN_ENDS_WITH = "_vector"
 
 
 class QueryInput(BaseModel):
     query: str
+
 
 class VectorSearchTool(BaseTool):
     def __init__(
@@ -59,7 +61,12 @@ def get_table_columns(
     table_info = workspace_client.tables.get(full_table_name)
 
     return [
-        col.name for col in table_info.columns if not (col.name.startswith(CONTENT_VECTOR_COLUMN_STARTS_WITH) and col.name.endswith(CONTENT_VECTOR_COLUMN_ENDS_WITH) )
+        col.name
+        for col in table_info.columns
+        if not (
+            col.name.startswith(CONTENT_VECTOR_COLUMN_STARTS_WITH)
+            and col.name.endswith(CONTENT_VECTOR_COLUMN_ENDS_WITH)
+        )
     ]
 
 


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?


In Databricks, vector columns that are automatically created when building a vector index typically follow a specific naming pattern, for example, a column named merged_text will produce a vector column named __db_merged_text_vector by default

Previously, the pattern used to filter out these vector columns was hardcoded and fixed, which could lead to conflicts for custom indexes that a user may create (I was one of them)

This PR changes that logic by introducing explicit constants for the prefix and suffix patterns used to identify these vector columns. 


### How is this PR tested?

- [ X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

![image](https://github.com/user-attachments/assets/8a7ce0c5-0584-42d8-8464-daec54b149a1)

### Does this PR require documentation update?

- [ X] No. You can skip the rest of this section.
- [ ] Yes. I've updated the relevant server README.md

### Release Notes

#### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes.

#### How should the PR be classified in the release notes? Choose one:

- [x ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

